### PR TITLE
Add test target. Use Cask for dependency management

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,0 +1,10 @@
+(source melpa)
+
+(package-file "magit-gh-comments.el")
+
+(depends-on "magit" "2.11.0")
+(depends-on "magit-gh-pulls" "0.5.3")
+(depends-on "request" "0.3.0")
+
+(development
+ (depends-on "ert-runner"))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+ test:
+	cask emacs -q \
+		-L $(CURDIR) \
+		-l test-magit-gh-comments.el \
+		-f ert-run-tests-batch-and-exit

--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -1,5 +1,7 @@
 ;; -*- lexical-binding: t -*-
 
+(require 'cl)
+(require 'json)
 (require 'request)
 (require 'magit-git)
 

--- a/magit-gh-comments.el
+++ b/magit-gh-comments.el
@@ -1,5 +1,38 @@
-;; -*- lexical-binding: t -*-
+;;; magit-gh-comments.el --- Comment on Github Pull Requests via Magit  -*- lexical-binding: t; coding: utf-8 -*-
 
+;; Copyright (C) 2018 Andrew Stahlman
+
+;; Author: Andrew Stahlman <andrewstahlman@gmail.com>
+;; Created: 28 Jun 2018
+;; Version: 0.1
+
+;; Keywords: tools git vc
+;; Homepage: https://github.com/astahlman/magit-gh-comments
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; Package-Requires: ((magit "2.11.0") (magit-gh-pulls "0.5.3") (request "0.3.0") (emacs "26.0"))
+
+;;; Commentary:
+;; This package enables the user to view and post comments on Github
+;; Pull Requests.
+
+;;; Code:
+
+(require 'cl)
 (require 'ert)
 
 (require 'magit-gh-comments-github)
@@ -209,3 +242,5 @@ Github-style position."
                                comment-text)))
 
 (provide 'magit-gh-comments)
+
+;;; magit-gh-comments.el ends here


### PR DESCRIPTION
Declare dependencies in a Cask file, add a proper package header, and
add a Makefile target to run ERT tests ('make test').