### PR TITLE
Add and display comments for current PR

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "magit-gh-comments.el")

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
- test:
-	cask emacs -q \
-		-L $(CURDIR) \
-		-l test-magit-gh-comments.el \
-		-f ert-run-tests-batch-and-exit
+.PHONY: test
+test:
+	cask exec ert-runner -L $(CURDIR)

--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -3,7 +3,15 @@
 (require 'request)
 (require 'magit-git)
 
+(defconst MAGIT-GH-DEBUG t)
 (defstruct magit-gh-pr owner repo-name pr-number)
+
+(setq request-message-level 'debug)
+(setq request-log-level 'debug)
+
+(setq magit-gh-comment-test-pr (make-magit-gh-pr :owner "astahlman"
+                                                 :repo-name "magit-gh-comments"
+                                                 :pr-number 3))
 
 (defun magit-gh--get-oauth-token ()
   (let ((token (magit-get "github" "oauth-token")))
@@ -20,32 +28,28 @@
 (defun magit-gh--url-for-pr-comments (pr)
   (format "%s/comments" (magit-gh--url-for-pr pr)))
 
-(defun magit-gh--fetch-diff-from-github (pr target-buf)
-  (request
-   (magit-gh--url-for-pr pr)
-   :headers '(("Authorization" . (format "token %s" (magit-gh--get-oauth-token)))
-              ("Accept" . "application/vnd.github.v3.diff"))
-   :parser (lambda ()
-             (let ((diff-content (buffer-substring (point-min) (point-max))))
-               (with-current-buffer target-buf
-                 (goto-char (point-min))
-                 (insert diff-content))))
-   :error (function*
-           (lambda (&key error-thrown &allow-other-keys)
-             (error "Failed to fetch diff from Github: %s" error-thrown)))))
-
-(setq magit-gh-comment-test-pr (make-magit-gh-pr :owner "astahlman"
-                                                 :repo-name "magit-gh-comments"
-                                                 :pr-number 2))
+(defun magit-gh--fetch-diff-from-github (pr)
+  (if MAGIT-GH-DEBUG
+      magit-gh--cached-diff
+      (let ((result))
+        (request
+         (magit-gh--url-for-pr pr)
+         :headers '(("Authorization" . (format "token %s" (magit-gh--get-oauth-token)))
+                    ("Accept" . "application/vnd.github.v3.diff"))
+         :parser (lambda ()
+                   (setq result (buffer-string)))
+         :sync t
+         :error (function*
+                 (lambda (&key error-thrown &allow-other-keys)
+                   (error "Failed to fetch diff from Github: %s" error-thrown))))
+        (setq magit-gh--cached-diff result)
+        result)))
 
 (defun magit-gh--comment-as-json (filename commit-sha gh-pos comment-text)
   (json-encode `((:body . ,comment-text)
                  (:commit_id . ,commit-sha)
                  (:path . ,filename)
                  (:position . ,gh-pos))))
-
-(magit-gh--comment-as-json "test-file.txt" "562b1f07ede9c579ae5ec2d79a07879dd7a0d031" 7 "hi")
-(magit-gh--fetch-diff-from-github magit-gh-comment-test-pr (get-buffer-create "pr-2-diffs"))
 
 (defun magit-gh--post-pr-comment (pr filename commit-id gh-pos comment-text)
   (let ((url (magit-gh--url-for-pr-comments pr))
@@ -67,16 +71,54 @@
                (if (not (member (request-response-status-code response) '(200 201)))
                    (error "Failed to post comment to %s" url)))))))
 
-
 (defun magit-gh--list-comments (pr)
-  (let ((url (magit-gh--url-for-pr-comments pr)))
-    (request
-     url
-     :headers '(("Authorization" . (format "token %s" (magit-gh--get-oauth-token))))
-     :parser (lambda ()
-               (write-file "/tmp/response2.txt")))))
+  "Return a list of comments that aren't outdated for the given
+PR. A comment is outdated if its position is null, according to
+Github. Each element of the result is an alist with the following keys:
 
-(setq request-message-level 'debug)
-(setq request-log-level 'debug)
+:body - The text of the comment
+:position - The comment's Github-style position in the diff
+:author - The Github username of the comments' author
+:path - The path to the file to which this comment applies"
+  (let ((comment-fields '(body position author path))
+        (url (magit-gh--url-for-pr-comments pr))
+        (alist-filter (lambda (keys alist)
+                        (filter 'identity ;; remove nils
+                                (mapcar (lambda (k)
+                                          (assoc k alist))
+                                        keys))))
+        (outdated-p (lambda (comment) (not (alist-get 'position comment))))
+        (alist-map-keys (lambda (fn alist)
+                          (let ((result))
+                            (reverse
+                             (dolist (cell alist result)
+                               (setq result
+                                     (cons
+                                      (cons (funcall fn (car cell))
+                                            (cdr cell))
+                                      result)))))))
+        (sym-to-keyword (lambda (x) (intern (format ":%s" x))))
+        (result))
+    (progn
+      (if MAGIT-GH-DEBUG
+          (setq result magit-gh--cached-comments)
+        (request
+         url
+         :headers '(("Authorization" . (format "token %s" (magit-gh--get-oauth-token))))
+         :parser (lambda ()
+                   (let ((json-array-type 'list))
+                     (json-read-array)))
+         :sync t
+         :success) (cl-function
+                    (lambda (&key data &allow-other-keys)
+                      (dolist (comment (remove-if outdated-p data))
+                        (setq result
+                              (cons (funcall alist-filter
+                                             comment-fields
+                                             comment)
+                                    result))
+                        (setq magit-gh--cached-comments result)))))
+      (mapcar (lambda (l) (funcall alist-map-keys sym-to-keyword l))
+              (reverse result)))))
 
 (provide 'magit-gh-comments-github)

--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -7,8 +7,8 @@
 
 (defstruct magit-gh-pr owner repo-name pr-number)
 
-(setq request-message-level 'debug)
-(setq request-log-level 'debug)
+(setq request-message-level 'info)
+(setq request-log-level 'info)
 
 (setq magit-gh-comment-test-pr (make-magit-gh-pr :owner "astahlman"
                                                  :repo-name "magit-gh-comments"

--- a/magit-gh-comments.el
+++ b/magit-gh-comments.el
@@ -407,6 +407,8 @@ which they came, add them to current magit-diff buffer."
       (delete-overlay overlay))))
 
 ;;;###autoload
+;; TODO: Assert that the current magit-gh-pull revision is up to date
+;; with HEAD of the PR branch
 (defun magit-gh-refresh-comments ()
   "Refresh comments for the current PR."
   (interactive)

--- a/magit-gh-comments.el
+++ b/magit-gh-comments.el
@@ -36,8 +36,6 @@
 (require 'ert)
 (require 'magit-gh-comments-github)
 
-;;; Code:
-
 (defstruct magit-gh-diff-pos a-or-b hunk-start offset)
 (defstruct magit-gh-comment file diff-pos text)
 
@@ -376,8 +374,8 @@ which they came, add them to current magit-diff buffer."
     (error "Couldn't fetch the PR associated with this diff! (This is likely a bug)")))
 
 
-;;; Capture and store the associated PR when the user views its diff
-;;; from the magit Pull Requests section
+;; Capture and store the associated PR when the user views its diff
+;; from the magit Pull Requests section
 (define-advice magit-gh-pulls-diff-pull-request (:around (original-fn) capture-current-pull-request)
   (let ((section-val (magit-section-value (magit-current-section))))
     (funcall original-fn)

--- a/magit-gh-comments.el
+++ b/magit-gh-comments.el
@@ -247,7 +247,7 @@ the header of a new section in the diff.
    -> '((:a . \"magit-gh-comments-github.el\")
         (:b . \"magit-gh-comments-github.el\"))"
 
-  (let ((file-header-re "diff --git a/\\([^ ]+\\) b/\\([^ ]+\\)$"))
+  (let ((file-header-re "^diff --git a/\\([^ ]+\\) b/\\([^ ]+\\)$"))
     (when (string-match file-header-re line)
       `((:a . ,(match-string-no-properties 1 line))
         (:b . ,(match-string-no-properties 2 line))))))
@@ -257,7 +257,6 @@ the header of a new section in the diff.
                    (:b . "bar"))
              (magit-gh--try-parse-file-header "diff --git a/foo b/bar")))
   (should-not (magit-gh--try-parse-file-header "+ This is not a match")))
-
 
 
 (defun magit-gh--diff-pos/magit->gh (file pos diff-body)
@@ -321,7 +320,6 @@ GH-DIFF-BODY, return the corresponding magit-gh-diff-pos."
             (offset 0))
         (while (not (magit-gh--try-parse-hunk-header))
           (assert (= 0 (forward-line -1)))
-          ;; (beginning-of-line)
           (unless (or (and (eq rev :a) (looking-at "^\\+"))
                       (and (eq rev :b) (looking-at "^-")))
             (cl-incf offset)))

--- a/test-magit-gh-comments.el
+++ b/test-magit-gh-comments.el
@@ -75,16 +75,16 @@
     (forward-line n)
     (buffer-substring (1+ (point-at-bol)) (point-at-eol))))
 
-(ert-deftest test-magit-gh--translate-diff-pos ()
+(ert-deftest test-magit-gh--diff-pos/magit->gh ()
   (let* ((rev-files (magit-gh--generate-revisions))
          (magit-diff-buf (magit-gh--generate-magit-diff (car rev-files) (cdr rev-files)))
          (random-line-in-diff (magit-gh--pick-random-line-in-diff magit-diff-buf)) ;; TODO: This is a terrible var name
          (diff-pos (alist-get :diff-pos random-line-in-diff))
          (expected-line-contents (alist-get :line-contents random-line-in-diff))
-         (github-diff-pos (with-current-buffer magit-diff-buf
-                            (magit-gh--translate-diff-pos diff-pos))))
+         (magit-diff-body (with-current-buffer magit-diff-buf (buffer-substring (point-min) (point-max))))
+         (github-diff-pos (magit-gh--diff-pos/magit->gh diff-pos magit-diff-body))
     (should (string= expected-line-contents
                      (magit-gh--line-contents-at-github-pos github-diff-pos
-                                                            magit-diff-buf)))))
+                                                            magit-diff-buf))))))
 
 (ert "test-magit-gh--.*")

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -1,0 +1,24 @@
+;; -*- lexical-binding: t -*-
+
+(require 'ert)
+(require 'magit-gh-comments)
+
+(ert-deftest test-magit-gh--diff-pos/magit->gh ()
+  (let* ((rev-files (magit-gh--generate-revisions))
+         (magit-diff-buf (magit-gh--generate-magit-diff (car rev-files) (cdr rev-files)))
+         (random-diff-pos (magit-gh--pick-random-diff-pos magit-diff-buf))
+         (diff-pos (alist-get :diff-pos random-diff-pos))
+         (expected-line-contents (alist-get :line-contents random-diff-pos))
+         (magit-diff-body (with-current-buffer magit-diff-buf (buffer-substring (point-min) (point-max))))
+         (github-diff-pos (magit-gh--diff-pos/magit->gh diff-pos magit-diff-body))
+    (should (string= expected-line-contents
+                     (magit-gh--line-contents-at-github-pos github-diff-pos
+                                                            magit-diff-buf))))))
+
+;; TODO:
+;; 1. Post a comment on line L in a diff
+;; 2. Close the buffer
+;; 3. Re-open the diff buffer
+;; 4. Assert that the comment is present on line L
+
+(ert "test-magit-gh--.*")

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -9,8 +9,11 @@
          (random-diff-pos (magit-gh--pick-random-diff-pos magit-diff-buf))
          (diff-pos (alist-get :diff-pos random-diff-pos))
          (expected-line-contents (alist-get :line-contents random-diff-pos))
-         (magit-diff-body (with-current-buffer magit-diff-buf (buffer-substring (point-min) (point-max))))
-         (github-diff-pos (magit-gh--diff-pos/magit->gh diff-pos magit-diff-body))
+         (github-diff-body (with-current-buffer (magit-gh--generate-github-diff)
+                             (buffer-substring-no-properties (point-min) (point-max))))
+         (github-diff-pos (magit-gh--diff-pos/magit->gh (cdr rev-files)
+                                                        diff-pos
+                                                        github-diff-body))
     (should (string= expected-line-contents
                      (magit-gh--line-contents-at-github-pos github-diff-pos
                                                             magit-diff-buf))))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,8 +1,7 @@
-;; -*- lexical-binding: t -*-
+;;; test-helper.el --- Helpers for magit-gh-comments-test.el
 
-(require 'ert)
+(require 'magit)
 
-(require 'magit-gh-comments)
 
 (defun magit-gh--gen-random-string (str-len)
   (let ((gen-random-char (lambda (n) (+ ?a (random 26)))))
@@ -79,16 +78,5 @@
     (forward-line n)
     (buffer-substring (1+ (point-at-bol)) (point-at-eol))))
 
-(ert-deftest test-magit-gh--diff-pos/magit->gh ()
-  (let* ((rev-files (magit-gh--generate-revisions))
-         (magit-diff-buf (magit-gh--generate-magit-diff (car rev-files) (cdr rev-files)))
-         (random-diff-pos (magit-gh--pick-random-diff-pos magit-diff-buf)) ;; TODO: This is a terrible var name
-         (diff-pos (alist-get :diff-pos random-diff-pos))
-         (expected-line-contents (alist-get :line-contents random-diff-pos))
-         (magit-diff-body (with-current-buffer magit-diff-buf (buffer-substring (point-min) (point-max))))
-         (github-diff-pos (magit-gh--diff-pos/magit->gh diff-pos magit-diff-body))
-    (should (string= expected-line-contents
-                     (magit-gh--line-contents-at-github-pos github-diff-pos
-                                                            magit-diff-buf))))))
 
-(ert "test-magit-gh--.*")
+;;; test-helper.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -45,7 +45,7 @@
         (num-context-lines (number-to-string (+ 3 (random 5)))))
     (when (get-buffer buf-name)
       (kill-buffer buf-name))
-    (call-process "git" nil buf-name nil "--no-pager" "diff" "-U" num-context-lines "--no-index" "/tmp/a.txt" "/tmp/b.txt")
+    (call-process "git" nil buf-name nil "--no-pager" "diff" (format "-U%s" num-context-lines) "--no-index" "/tmp/a.txt" "/tmp/b.txt")
     buf-name))
 
 


### PR DESCRIPTION
Fetch comments for the current PR and display them in the diff buffer.

Declare dependencies in a Cask file, add a proper package header, and
add a Makefile target to run ERT tests ('make test').