### PR TITLE
Add review-centric view

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 (depends-on "magit" "2.11.0")
 (depends-on "magit-gh-pulls" "0.5.3")
 (depends-on "request" "0.3.0")
+(depends-on "dash" "2.14.1")
 
 (development
  (depends-on "ert-runner"))

--- a/magit-gh-comments-diff.el
+++ b/magit-gh-comments-diff.el
@@ -16,10 +16,4 @@
                           (t 'magit-diff-context)))
       (forward-line 1))))
 
-(defun magit-gh--visit-diff-pos (file magit-gh-pos)
-  ;; 1. If pos.a-or-b == :b:
-  ;; 2. Open a buffer pointing to the file (TODO: from worktree or blob?)
-  ;; 3. Extract the hunk start and offset from the magit-gh-pos
-  ;; 4. Move forward hunk-start + offset
-  )
 (provide 'magit-gh-comments-diff)

--- a/magit-gh-comments-diff.el
+++ b/magit-gh-comments-diff.el
@@ -1,0 +1,25 @@
+(defconst magit-gh--hunk-header-re "@@ -\\([0-9]+\\),\\([0-9]+\\) \\+\\([0-9]+\\),\\([0-9]+\\) @@")
+
+(defun magit-gh--jump-to-file-in-diff (file)
+  (if-let ((result (or (re-search-forward (format "^\\(copy\\|rename\\) to %s$" file) nil t)
+                       (re-search-forward (format "+++ b/%s" file) nil t))))
+      result
+    (error "Could not find file '%s' in diff!" file)))
+
+(defun magit-gh--paint-diff ()
+  (while (re-search-forward magit-gh--hunk-header-re nil t)
+    (while (not (eobp))
+      (put-text-property (point) (min (point-max) (1+ (line-end-position))) 'face
+                         (cond
+                          ((looking-at-p "^\\+") 'magit-diff-added)
+                          ((looking-at "^-") 'magit-diff-removed)
+                          (t 'magit-diff-context)))
+      (forward-line 1))))
+
+(defun magit-gh--visit-diff-pos (file magit-gh-pos)
+  ;; 1. If pos.a-or-b == :b:
+  ;; 2. Open a buffer pointing to the file (TODO: from worktree or blob?)
+  ;; 3. Extract the hunk start and offset from the magit-gh-pos
+  ;; 4. Move forward hunk-start + offset
+  )
+(provide 'magit-gh-comments-diff)

--- a/magit-gh-utils.el
+++ b/magit-gh-utils.el
@@ -1,0 +1,31 @@
+(defun magit-gh--pretty-print (x)
+  "Pretty print the form X in a buffer named *pretty*"
+  (when (get-buffer "*pretty*")
+    (kill-buffer "*pretty*"))
+  (with-current-buffer (get-buffer-create "*pretty*")
+    (cl-prettyprint x))
+  (view-buffer-other-window "*pretty*"))
+
+(magit-gh--pretty-print magit-gh--request-cache)
+
+(defun magit-gh--comment-at-point ()
+  "Return the comment overlay at point, if it exists."
+  (car (-filter (lambda (ov) (and (overlay-get ov 'magit-gh-comment)
+                                  (>= (overlay-start ov) (point))
+                                  (<= (overlay-end ov) (point))))
+                (-flatten (overlay-lists)))))
+
+(defun overlays-at-point ()
+  "Return overlays which touch point.
+
+The start and end of the overlays are inclusive."
+  (interactive)
+  (filter (lambda (ov) (and (>= (point) (overlay-start ov))
+                            (<= (point) (overlay-end ov))))
+          (-flatten (overlay-lists))))
+
+
+(defun delete-overlays-at-point ()
+  (interactive)
+  (dolist (ov (overlays-at-point))
+    (delete-overlay ov)))

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -160,48 +160,6 @@ index 9fda99d..f88549a 100644
                                   (:position . 9)))
                                (magit-gh--list-comments magit-gh--test-pr))))))
 
-;; (setq test-reviews (magit-gh--list-reviews magit-gh--test-pr))
-
-;; TODO: Delete?
-(defun magit-gh--jump-to-file-section (file)
-  (interactive "sFile name: ")
-  (goto-char (point-min))
-  (let (foundp)
-    (while (not foundp)
-      (magit-section-when
-          (and (equalp file (oref it type))
-               (equalp (format "b/%s" file)
-                       (oref it value)))
-        (setq foundp t))
-      (when (not foundp)
-        (magit-section-forward)))))
-
-
-(defun magit-gh--comment-ctx (diff-body gh-pos file)
-  (letfn ((walk-within-hunk (lambda (n)
-                              "Walk N lines, stopping at hunk headers"
-                              (when (looking-at-p magit-gh--hunk-header-re)
-                                (error "Position must be inside a hunk!"))
-                              (while (and (not (zerop n))
-                                          (not (looking-at-p magit-gh--hunk-header-re)))
-                                (forward-line (/ n (abs n)))
-                                (setq n (- n (/ n (abs n))))))))
-         (save-excursion
-           (magit-gh--with-temp-buffer
-             (insert diff-body)
-             (goto-char (point-min))
-             (magit-gh--paint-diff)
-             (goto-char (point-min))
-             (magit-gh--jump-to-file-in-diff file)
-             (re-search-forward magit-gh--hunk-header-re)
-             (forward-line gh-pos)
-             (let* ((num-lines-ctx-before 3)
-                    (beg (save-excursion (walk-within-hunk (* -1 num-lines-ctx-before))
-                                         (point)))
-                    (end (save-excursion (end-of-line)
-                                         (point))))
-               (format "%s\n%s" file (buffer-substring beg end)))))))
-
 (ert-deftest magit-gh--test-comment-ctx ()
   (let ((diff-body "diff --git a/f b/f
 index 9fda99d..f88549a 100644

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -2,6 +2,10 @@
 
 (require 'ert)
 (require 'magit-gh-comments)
+;; (require 'magit-gh-comments-diff)
+
+;; For running tests interactively
+;; (load "test/test-helper")
 
 (ert-deftest test-magit->gh/boundary-conditions ()
   (let* ((diff-body "diff --git a/f b/f
@@ -27,6 +31,7 @@ index 9fda99d..f88549a 100644
     (should (= 3 (funcall magit->gh :a 3)))
     (should (= 3 (funcall magit->gh :b 2)))))
 
+
 (ert-deftest test-magit-gh--diff-pos/magit->gh ()
   (let* ((rev-files (magit-gh--generate-revisions))
          (magit-diff-buf (magit-gh--generate-magit-diff (car rev-files) (cdr rev-files)))
@@ -48,4 +53,262 @@ index 9fda99d..f88549a 100644
 ;; 3. Re-open the diff buffer
 ;; 4. Assert that the comment is present on line L
 
-(ert "test-magit-gh--.*")
+
+(defmacro with-mocks (fn-defs &rest body)
+  (declare (indent 1) (debug ((&rest (sexp function-form)) body)))
+  (let ((bindings (mapcar
+                   (lambda (fn-def) `((symbol-function (quote ,(car fn-def))) ,(cadr fn-def)))
+                   fn-defs)))
+    `(cl-letf ,bindings
+       ,@body)))
+
+;; TODO: Move this definition out of the test, maybe reverse the
+;; direction of the alias (or just remove it)
+(defalias 'letfn #'with-mocks)
+
+(setq magit-gh--test-pr
+      (make-magit-gh-pr :owner "astahlman"
+                        :pr-number 0
+                        :repo-name "magit-gh-comments"
+                        :diff-range "abcdef"))
+
+(setq magit-gh--test-review-response
+      '(((id . 42)
+         (user (login . "astahlman"))
+         (body . "This is a top-level review with a \360\237\220\250 thrown in for good measure. Here's a code sample, too:
+
+```
+def foo():
+  print \"hi\"
+```")
+         (state . "COMMENTED")
+         (submitted_at . "2018-09-02T16:57:24Z")
+         (commit_id . "562b1f07ede9c579ae5ec2d79a07879dd7a0d031"))
+        ((id . 43)
+         (user (login . "spiderman"))
+         ;; NOTE: Spiderman did not leave a top-level review
+         (state . "COMMENTED")
+         (submitted_at . "2018-09-02T17:00:00Z")
+         (commit_id . "562b1f07ede9c579ae5ec2d79a07879dd7a0d031"))))
+
+(setq magit-gh--test-comments-response
+      '(((pull_request_review_id . 42)
+         (body . "A comment about the removal of line 2")
+         (path . "f")
+         (position . 2)
+         (user (login . "astahlman")))
+        ((pull_request_review_id . 43)
+         (body . "A comment about the addition of line 15")
+         (path . "f")
+         (position . 9)
+         (user (login . "spiderman")))))
+
+(setq magit-gh--test-diff-body "diff --git a/f b/f
+index 9fda99d..f88549a 100644
+--- a/f
++++ b/f
+@@ -1,3 +1,2 @@
+ 1. :a/1/1, :b/1/1
+-2. :a/1/2
+ 3. :a/1/3, :b/1/2
+@@ -11,3 +10,5 @@
+ 11. :a/11/1, :b/10/1
+ 12. :a/11/2, :b/10/2
++13. :b/10/3
+ 14. :a/11/3, :b/10/4
++15. :b/10/5
+\\ No newline at end of file
+")
+
+
+(defun mock-github-api (url &rest request-args)
+  (cond ((equalp url "https://api.github.com/repos/astahlman/magit-gh-comments/pulls/0/comments")
+         magit-gh--test-comments-response)
+        ((equalp url "https://api.github.com/repos/astahlman/magit-gh-comments/pulls/0/reviews")
+         magit-gh--test-review-response)
+        ((and (equalp url "https://api.github.com/repos/astahlman/magit-gh-comments/pulls/0")
+               ;; TODO: check that the args contain `:headers ("Accept" . "application/vnd.github.v3.diff")`
+               ;;(equalp request-args )
+              t)
+         magit-gh--test-diff-body)
+        (t (error "There is no mock configured for that request with URL `%s`" url))))
+
+(ert-deftest test-magit-gh--github-fetch-reviews ()
+  (with-mocks ((magit-gh--request-sync-internal #'mock-github-api))
+    (let* ((response (magit-gh--list-reviews magit-gh--test-pr))
+           (first-review (car response))
+           (first-comment (car (alist-get :comments first-review))))
+      (should (string-match-p "A comment about the removal of line 2"
+                              (alist-get :body first-comment)))
+      (should (string-match-p "This is a top-level review"
+                              (alist-get :body first-review))))))
+
+
+(ert-deftest test-magit-gh--github-fetch-comments ()
+  ;; TODO: Test against the comment context given this diff body
+  (let* ((diff-body magit-gh--test-diff-body))
+    (with-mocks ((magit-gh--request-sync-internal #'mock-github-api))
+                (should (equal '(((:pull_request_review_id . 42)
+                                  (:author . "astahlman")
+                                  (:body . "A comment about the removal of line 2")
+                                  (:path . "f")
+                                  (:position . 2))
+                                 ((:pull_request_review_id . 43)
+                                  (:author . "spiderman")
+                                  (:body . "A comment about the addition of line 15")
+                                  (:path . "f")
+                                  (:position . 9)))
+                               (magit-gh--list-comments magit-gh--test-pr))))))
+
+;; (setq test-reviews (magit-gh--list-reviews magit-gh--test-pr))
+
+;; TODO: Delete?
+(defun magit-gh--jump-to-file-section (file)
+  (interactive "sFile name: ")
+  (goto-char (point-min))
+  (let (foundp)
+    (while (not foundp)
+      (magit-section-when
+          (and (equalp file (oref it type))
+               (equalp (format "b/%s" file)
+                       (oref it value)))
+        (setq foundp t))
+      (when (not foundp)
+        (magit-section-forward)))))
+
+
+(defun magit-gh--comment-ctx (diff-body gh-pos file)
+  (letfn ((walk-within-hunk (lambda (n)
+                              "Walk N lines, stopping at hunk headers"
+                              (when (looking-at-p magit-gh--hunk-header-re)
+                                (error "Position must be inside a hunk!"))
+                              (while (and (not (zerop n))
+                                          (not (looking-at-p magit-gh--hunk-header-re)))
+                                (forward-line (/ n (abs n)))
+                                (setq n (- n (/ n (abs n))))))))
+         (save-excursion
+           (magit-gh--with-temp-buffer
+             (insert diff-body)
+             (goto-char (point-min))
+             (magit-gh--paint-diff)
+             (goto-char (point-min))
+             (magit-gh--jump-to-file-in-diff file)
+             (re-search-forward magit-gh--hunk-header-re)
+             (forward-line gh-pos)
+             (let* ((num-lines-ctx-before 3)
+                    (beg (save-excursion (walk-within-hunk (* -1 num-lines-ctx-before))
+                                         (point)))
+                    (end (save-excursion (end-of-line)
+                                         (point))))
+               (format "%s\n%s" file (buffer-substring beg end)))))))
+
+(ert-deftest magit-gh--test-comment-ctx ()
+  (let ((diff-body "diff --git a/f b/f
+index 9fda99d..f88549a 100644
+--- a/f
++++ b/f
+@@ -1,3 +1,2 @@
+ 1. :a/1/1, :b/1/1
+-2. :a/1/2
+ 3. :a/1/3, :b/1/2
+@@ -11,2 +10,3 @@
+ 11. :a/11/1, :b/10/1
+ 12. :a/11/2, :b/10/2
++13. :b/10/3
+ 14. :a/11/3, :b/10/4
++15. :b/10/5
+\\ No newline at end of file
+"))
+    (should (equalp "f
+@@ -1,3 +1,2 @@
+ 1. :a/1/1, :b/1/1
+-2. :a/1/2
+ 3. :a/1/3, :b/1/2"
+                    (magit-gh--str-without-props
+                     (magit-gh--comment-ctx diff-body 3 "f"))))
+    (should (equalp "f
+@@ -1,3 +1,2 @@
+ 1. :a/1/1, :b/1/1
+-2. :a/1/2"
+                    (magit-gh--str-without-props
+                     (magit-gh--comment-ctx diff-body 2 "f"))))
+    (should (equalp "f
+@@ -1,3 +1,2 @@
+ 1. :a/1/1, :b/1/1"
+                    (magit-gh--str-without-props
+                     (magit-gh--comment-ctx diff-body 1 "f"))))
+    (should (equalp "f
+@@ -11,2 +10,3 @@
+ 11. :a/11/1, :b/10/1
+ 12. :a/11/2, :b/10/2
++13. :b/10/3"
+                    (magit-gh--str-without-props
+                     (magit-gh--comment-ctx diff-body 7 "f"))))
+    (should (equalp "f
+@@ -11,2 +10,3 @@
+ 11. :a/11/1, :b/10/1
+ 12. :a/11/2, :b/10/2"
+                    (magit-gh--str-without-props
+                     (magit-gh--comment-ctx diff-body 6 "f"))))
+    (should (equalp "f
+@@ -11,2 +10,3 @@
+ 11. :a/11/1, :b/10/1"
+                    (magit-gh--str-without-props
+                     (magit-gh--comment-ctx diff-body 5 "f"))))
+    (should-error (magit-gh--comment-ctx diff-body 4 "f"))))
+
+(ert-deftest magit-gh--test-populate-reviews-buffer ()
+  (let ((magit-gh--current-pr magit-gh--test-pr)
+        magit-diff-calls
+        visit-diff-pos-calls)
+    (with-mocks ((magit-gh--request-sync-internal #'mock-github-api)
+                 (magit-diff (lambda (&rest args)
+                               (setq magit-diff-calls
+                                     (cons args magit-diff-calls))))
+                 (magit-gh--visit-diff-pos (lambda (&rest args)
+                                             (setq visit-diff-pos-calls
+                                                   (cons args visit-diff-pos-calls)))))
+      (magit-gh--populate-reviews magit-gh--test-pr)
+      (switch-to-buffer "magit-pull-request: magit-gh-comments/0")
+      (goto-char (point-min))
+      (should (magit-gh--looking-at-p "FIXME - PR TITLE HERE"))
+      ;; Review sections
+      (magit-section-forward)
+      (should (magit-gh--looking-at-p "Review by astahlman"))
+      (should (s-contains? "This is a top-level review"
+                           (magit-gh--section-content-as-string)))
+      (magit-section-forward)
+      (should (magit-gh--looking-at-p "f
+@@ -1,3 +1,2 @@
+ 1. :a/1/1, :b/1/1
+-2. :a/1/2
+A comment about the removal of line 2
+- astahlman"))
+      (forward-line 3)
+      (should (magit-gh--looking-at-p "-2. :a/1/2"))
+      (save-excursion
+        (execute-kbd-macro (kbd "<return>"))
+        (should (equal (car visit-diff-pos-calls)
+                       `("f" ,(make-magit-gh-diff-pos :a-or-b :a
+                                                      :hunk-start 1
+                                                      :offset 2))))
+        (should (equal (caar magit-diff-calls)
+                       (magit-gh-pr-diff-range magit-gh--test-pr))))
+      (magit-section-forward-sibling)
+      (should (magit-gh--looking-at-p "Review by spiderman"))
+      (magit-section-forward)
+      (should (magit-gh--looking-at-p "f
+ 12. :a/11/2, :b/10/2
++13. :b/10/3
+ 14. :a/11/3, :b/10/4
++15. :b/10/5
+A comment about the addition of line 15
+- spiderman"))
+      (forward-line 4)
+      (should (magit-gh--looking-at-p "+15. :b/10/5"))
+      (save-excursion
+        (execute-kbd-macro (kbd "<return>"))
+        (should (equal (car visit-diff-pos-calls)
+                       `("f" ,(make-magit-gh-diff-pos :a-or-b :b
+                                                      :hunk-start 10
+                                                      :offset 5))))))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -9,7 +9,7 @@ Unlike `looking-at-p', on failure this function reports the
 actual string at point. This makes it easier to diagnose test
 failures.
 "
-  (let ((result (looking-at-p (regexp-quote s))))
+  (let ((result (looking-at-p s)))
     (if (not result)
         (error (format "Expected to be looking at: %s\nActually looking at: %s"
                        s


### PR DESCRIPTION
Replace the initial, diff-centric view with a review-centric view. This
view is modeled after the Github web interface, in which reviews are
shown sequentially and each comment thread in the review is displayed
with a few lines of the diff for context.

Unlike the Github interface, this interfaces allows the user to jump
from a comment directly to the corresponding line in the diff (and from
a line in the diff to the corresponding line in the file).