### PR TITLE
Make magit-gh--current-pr buffer-local

### DIFF
--- a/magit-gh-comments-diff.el
+++ b/magit-gh-comments-diff.el
@@ -51,10 +51,12 @@ match and the match's length is returned."
         (let ((keymap (make-sparse-keymap)))
           (define-key keymap (kbd "<return>")
             (let ((filepath filepath)
-                  (diff-range diff-range))
+                  (diff-range diff-range)
+                  (pr (magit-gh--get-current-pr)))
               (lambda ()
                 (interactive)
                 (magit-diff diff-range)
+                (setq-local magit-gh--current-pr pr)
                 (if-let ((section (magit-get-section
                                    `((file . ,filepath) (diffbuf)))))
                     (progn

--- a/magit-gh-comments.el
+++ b/magit-gh-comments.el
@@ -501,7 +501,7 @@ magit-gh-pulls)"
 
 (defun magit-gh-comments-refresh-buffer (pr &rest _refresh-args)
   ;; We'll need a reference to the PR in our magit-diff refresh hook
-  (setq magit-gh--current-pr pr)
+  (setq-local magit-gh--current-pr pr)
   (magit-gh--hydrate-pr-from-github pr)
   (magit-gh--populate-reviews pr))
 


### PR DESCRIPTION
Stop making `magit-gh--current-pr` a global var so that it doesn't interfere with magit in other repos.

Also fix a couple of broken tests:
- `alist-get` doesn't accept `test-fn` as an arg until Emacs 26.1
- We weren't using the Github mock in one of the tests - not sure how I missed that. Maybe it's time for CI on check-in?