### PR TITLE
Remove carriage-returns from Github responses

### DIFF
--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -140,7 +140,8 @@ index 9fda99d..f88549a 100644
 
 
 (setq magit-gh--test-pr-response
-      '((body . "Fake PR description here")
+      '((body . "Fake PR description here
+With a carriage-return + line-feed.")
         (title . "PR Title")
         (state . "open")))
 
@@ -151,7 +152,7 @@ index 9fda99d..f88549a 100644
          magit-gh--test-review-response)
         ((and (equalp url "https://api.github.com/repos/astahlman/magit-gh-comments/pulls/0")
               (equalp "application/vnd.github.v3.diff"
-                      (cdr (assoc "Accept" (plist-get request-args :headers)))))
+                      (magit-gh--extract-header "Accept" request-args)))
          magit-gh--test-diff-body)
         ((equalp url "https://api.github.com/repos/astahlman/magit-gh-comments/pulls/0")
          magit-gh--test-pr-response)
@@ -346,7 +347,8 @@ index 9fda99d..f88549a 100644
       ;; PR Title and description
       (should (magit-gh--looking-at-p (regexp-quote "PR Title (#0) [OPEN]")))
       (forward-line 2)
-      (should (magit-gh--looking-at-p "Fake PR description here"))
+      (should (magit-gh--looking-at-p (regexp-quote "Fake PR description here
+With a carriage-return + line-feed.")))
       ;; Diffstat
       (magit-section-forward)
       (should (magit-gh--looking-at-p "Files changed"))


### PR DESCRIPTION
Github seems to use Windows-style new-lines, i.e., `\r\n`. The
carriage-returns are displayed as `^M` in Emacs, which is ugly.

This PR recursively strips any carriage-returns from the response from
Github, unless the response is not a list, which we're using as a
proxy for "not a diff." We should probably check against the "Accept"
type in the request headers instead. I started to go down that route
but then got lazy.