### PR TITLE
Implement review drafts (1/2)

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,6 +7,7 @@
 (depends-on "magit-gh-pulls" "0.5.3")
 (depends-on "request" "0.3.0")
 (depends-on "dash" "2.14.1")
+(depends-on "ht" "2.2")
 
 (development
  (depends-on "ert-runner"))

--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -16,6 +16,11 @@
   state
   body)
 
+(defun magit-gh-pr-to-string (pr)
+  (format "%s#%s"
+          (magit-gh-pr-repo-name pr)
+          (magit-gh-pr-pr-number pr)))
+
 (setq request-message-level 'debug)
 (setq request-log-level 'debug)
 
@@ -282,6 +287,10 @@ to colon-prefixed keywords. L can be an alist or a list of alists."
           (map-put review :comments
                    (cons comment review-comments))
           (map-put reviews review-id review))))))
+
+;; TODO: Implement me!
+(defun magit-gh--post-review (pr review)
+  )
 
 ;; (setq my-reviews (magit-gh--list-reviews magit-gh-comment-test-pr))
 ;; (magit-gh--pretty-print my-reviews)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -85,7 +85,7 @@ failures.
       (setq num-changes (how-many "^[-\\+]"))
       (re-search-forward "^[-\\+]\\(.+\\)" nil nil (1+ (random num-changes)))
       `((:line-contents . ,(match-string 1))
-        (:diff-pos . ,(magit-gh--cur-diff-pos))))))
+        (:diff-pos . ,(magit-gh--cur-magit-diff-pos))))))
 
 (defun magit-gh--line-contents-at-github-pos (n diff-buf)
   (with-current-buffer diff-buf


### PR DESCRIPTION
Change the default behavior of the add-comment command to store the
comments without actually posting them. Add unit tests for adding
comments.

Not yet implemented: the call to Github to actually POST the review.