### PR TITLE
Refactoring: represent review as struct instead of alist

### DIFF
--- a/magit-gh-comments-utils.el
+++ b/magit-gh-comments-utils.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t -*-
+
 (defun magit-gh--pretty-print (x)
   "Pretty print the form X in a buffer named *pretty*"
   (when (get-buffer "*pretty*")
@@ -6,8 +8,6 @@
     (cl-prettyprint x))
   (view-buffer-other-window "*pretty*"))
 
-(magit-gh--pretty-print magit-gh--request-cache)
-
 (defun magit-gh--comment-at-point ()
   "Return the comment overlay at point, if it exists."
   (car (-filter (lambda (ov) (and (overlay-get ov 'magit-gh-comment)
@@ -15,7 +15,7 @@
                                   (<= (overlay-end ov) (point))))
                 (-flatten (overlay-lists)))))
 
-(defun overlays-at-point ()
+(defun magit-gh--overlays-at-point ()
   "Return overlays which touch point.
 
 The start and end of the overlays are inclusive."
@@ -24,8 +24,7 @@ The start and end of the overlays are inclusive."
                             (<= (point) (overlay-end ov))))
           (-flatten (overlay-lists))))
 
-
-(defun delete-overlays-at-point ()
+(defun magit-gh--delete-overlays-at-point ()
   (interactive)
   (dolist (ov (overlays-at-point))
     (delete-overlay ov)))

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -164,11 +164,11 @@ With a carriage-return + line-feed.")
   (with-mocks ((magit-gh--request-sync-internal #'mock-github-api))
     (let* ((response (magit-gh--list-reviews magit-gh--test-pr))
            (first-review (car response))
-           (first-comment (car (alist-get :comments first-review))))
+           (first-comment (car (magit-gh-review-comments first-review))))
       (should (string-match-p "A comment about the removal of line 2"
                               (alist-get :body first-comment)))
       (should (string-match-p "This is a top-level review"
-                              (alist-get :body first-review))))))
+                              (magit-gh-review-body first-review))))))
 
 (defun magit-gh--discard-empty-keys (l)
   (let (result)


### PR DESCRIPTION
Return a list of structs from `magit-gh-list-reviews' instead of a
list of alists. We're now consistent in our internal representation of
reviews as using the `magit-gh-review' struct.

I also switched to using hashtables in the implementation of
`magit-gh-list-reviews'. Dealing with three levels of nesting in the
grouped list of alists was getting hard to reason about.