### PR TITLE
Add minor mode for editing comments

### DIFF
--- a/magit-gh-comments-prose.el
+++ b/magit-gh-comments-prose.el
@@ -1,0 +1,97 @@
+;; -*- lexical-binding: t -*-
+
+(require 'magit-gh-comments-utils)
+
+(define-minor-mode magit-gh-prose-mode
+  "Minor mode for editing long-form prose in magit-gh
+
+This minor mode is turned on when editing the body of a review or a comment."
+  :lighter " magit-gh-prose"
+  :keymap (let ((keymap (make-sparse-keymap)))
+            (define-key keymap (kbd "C-c '") 'magit-gh-prose-save-and-exit)
+            (define-key keymap (kbd "C-g") 'magit-gh-prose-abort)
+            keymap))
+
+(defun magit-gh-prose-return-to-source-buffer ()
+  (unless magit-gh-prose-source-buffer
+    (error "[magit-gh-comments] We lost the source buffer! This is probably a bug"))
+  (let ((edit-buffer (current-buffer)))
+    (switch-to-buffer-other-window magit-gh-prose-source-buffer)
+    (delete-other-windows)
+    (kill-buffer edit-buffer)))
+
+(defun magit-gh-prose-replace-section-content (section content)
+  (save-excursion
+    (with-current-buffer magit-gh-prose-source-buffer
+      (let* ((start (marker-position (or (oref section content)
+                                         (oref section start))))
+             (old-len (- (oref section end) start))
+             (new-len (length content)))
+        (goto-char start)
+        ;; TODO: We shouldn't set this keymap in multiple places
+        (let ((text (magit-gh--text-with-keymap content
+                                              `(,(kbd "C-c '") . ,'magit-gh--edit-prose))))
+          (insert (propertize text 'magit-section section)))
+        (insert "\n")
+        (delete-region (point)
+                       (+ (point) old-len))
+        (setf (oref section start) (progn (goto-char start)
+                                          (point-marker)))
+        (setf (oref section end) (progn (goto-char (+ start new-len))
+                                        (point-marker)))))))
+
+(defun magit-gh-prose-save-and-exit ()
+  (interactive)
+  (let ((edit-buffer (current-buffer))
+        (section magit-gh-prose-section-being-edited)
+        (content (buffer-substring (point-min) (point-max))))
+    (when (not (string-empty-p content))
+      (setf (oref section value) content)
+      (let ((inhibit-read-only t))
+        (magit-gh-prose-replace-section-content section content))
+      (setq-local magit-gh-prose-ready-for-exit t)
+      (magit-gh-prose-return-to-source-buffer))))
+
+(defun magit-gh-prose-abort ()
+  (interactive)
+  (setq-local magit-gh-prose-ready-for-exit t)
+  (magit-gh-prose-return-to-source-buffer))
+
+(defun magit-gh--confirm-kill-edit-prose-buf ()
+  (if (and (bound-and-true-p magit-gh-prose-section-being-edited)
+           (buffer-modified-p)
+           (not (bound-and-true-p magit-gh-prose-ready-for-exit)))
+      (yes-or-no-p "Discard unsaved changes? [y/n]")
+    t))
+
+(defun magit-gh--init-prose-editor (section source-buffer)
+  (magit-gh-prose-mode 1)
+  (setq-local magit-gh-prose-section-being-edited
+              section)
+  (setq-local magit-gh-prose-source-buffer
+              source-buffer)
+  (setq-local header-line-format
+              (substitute-command-keys
+               "Edit, then save and exit with `\\[magit-gh-prose-save-and-exit]' or abort and discard changes with \
+`\\[magit-gh-prose-abort]'"))
+  (when (not (memq 'magit-gh--confirm-kill-edit-prose-buf kill-buffer-query-functions))
+    (add-to-list 'kill-buffer-query-functions 'magit-gh--confirm-kill-edit-prose-buf))
+  (when-let ((initial-text (oref section value)))
+    (insert initial-text)))
+
+(defun magit-gh--edit-prose ()
+  (interactive)
+  (let* ((section (magit-current-section))
+         (source-buffer (current-buffer))
+         (buf-name (format "magit-gh: %s" (oref section type)))
+         (buf (get-buffer-create buf-name))
+         (keymap (make-sparse-keymap)))
+    (when (not section)
+      (user-error "Point must be on a magit-section before editing"))
+    (delete-other-windows)
+    (switch-to-buffer-other-window buf)
+    (magit-gh--init-prose-editor section source-buffer)))
+
+(provide 'magit-gh-comments-prose)
+
+;;; magit-gh-comments-prose.el ends here

--- a/magit-gh-comments-utils.el
+++ b/magit-gh-comments-utils.el
@@ -28,3 +28,16 @@ The start and end of the overlays are inclusive."
   (interactive)
   (dolist (ov (overlays-at-point))
     (delete-overlay ov)))
+
+;; TODO: This probably doesn't belong here
+(defun magit-gh--text-with-keymap (s &rest bindings)
+  "Propertize string S with BINDINGS added to 'keymap.
+
+Each element of BINDINGS is a dotted pair of a (kbd) keycode and
+a function"
+  (let ((keys (make-sparse-keymap)))
+    (dolist (binding bindings)
+      (define-key keys (car binding) (cdr binding)))
+    (propertize s 'keymap keys)))
+
+(provide 'magit-gh-comments-utils)

--- a/test/magit-gh-prose-test.el
+++ b/test/magit-gh-prose-test.el
@@ -1,0 +1,51 @@
+(require 'cl)
+(require 'magit-gh-comments-prose)
+
+(defmacro with-point-on-magit-section (content &rest body)
+  (declare (indent 1) (debug t))
+  (let ((section (gensym)))
+    `(let (,section)
+       (magit-insert-section (test)
+         (magit-insert-heading "Fake Review Body Header")
+         (insert ,content))
+       (magit-section-backward)
+       (setq ,section (magit-current-section))
+       (setf (oref ,section value) ,content)
+       ,@body
+       ,section)))
+
+(ert-deftest magit-gh-test-populate-empty-section ()
+  (magit-gh--with-temp-buffer
+    (let ((section (with-point-on-magit-section ""
+                     (magit-gh--edit-prose))))
+      (insert "foo")
+      ;; save-and-exit
+      (execute-kbd-macro (kbd "C-c '"))
+      (should (string= (oref section value)
+                       "foo"))
+      (should (string= (oref section value)
+                       (magit-gh--section-content-as-string section))))))
+
+(ert-deftest magit-gh-test-edit-save-and-exit ()
+  (magit-gh--with-temp-buffer
+    (let ((section (with-point-on-magit-section "foo"
+                     (magit-gh--edit-prose))))
+      (insert " bar")
+      ;; save-and-exit
+      (execute-kbd-macro (kbd "C-c '"))
+      (should (string= (oref section value)
+                       "foo bar"))
+      (should (string= (oref section value)
+                       (magit-gh--section-content-as-string section))))))
+
+(ert-deftest magit-gh-test-edit-and-abort ()
+  (magit-gh--with-temp-buffer
+    (let ((section (with-point-on-magit-section "foo"
+                     (magit-gh--edit-prose))))
+      (insert "None of this will be saved")
+      ;; abort
+      (execute-kbd-macro (kbd "C-g"))
+      (should (string= (oref section value)
+                       "foo"))
+      (should (string= (oref section value)
+                       (magit-gh--section-content-as-string section))))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -102,14 +102,17 @@ failures.
     (with-current-buffer (get-buffer-create buf-name) (insert contents))
     buf-name))
 
-(defun magit-gh--section-content-as-string (&optional section)
+(defun magit-gh--section-content-as-string (&optional section include-heading)
   "Return the content of SECTION as a string.
 
 If SECTION is not supplied, use the value of
 `magit-current-section'."
   (let ((section (or section (magit-current-section))))
-    (buffer-substring-no-properties (oref section start)
-                                    (oref section end))))
+    (buffer-substring (if include-heading
+                          (oref section start)
+                        (or (oref section content)
+                            (oref section start)))
+                      (oref section end))))
 
 
 (defun magit-gh--str-without-props (s)


### PR DESCRIPTION
I'm not happy with this approach and I plan to refactor it.

Currently, magit-gh-comments mode is initialized with a PR and an
"action" keyword arg, one of `:view-pr` or `:submit-review`. We
populate the buffer differently depending on the action.

Instead, I want to split this into two separate minor modes.

Another thing I don't like about this is the way the prose minor- mode
replaces the content of a magit-section. It took a lot of fiddling to
get the `start` and `end` of the magit-section populated correctly,
and I'm not convinced the current implementation is very robust. I
think magit sections just aren't meant to be mutable.

A cleaner approach would be to just to initialize the buffer with a
callback that runs when editing is complete. That hook will update the
pending review draft and then refresh the src buffer, which will
automatically pick up and redisplay the new content.