### PR TITLE
Fail-fast on submission if review not started

### DIFF
--- a/magit-review.el
+++ b/magit-review.el
@@ -45,6 +45,8 @@ See also `magit-buffer-lock-functions'."
 
 (defun magit-gh-submit-review ()
   (interactive)
+  (when (not (derived-mode-p 'magit-review-mode))
+    (user-error "Start a review with `magit-start-review' before submitting."))
   (let* ((state 'comment) ;; TODO: Make this configurable
          (pr (magit-gh--get-current-pr))
          (review (or (magit-gh--get-review-draft pr)

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -479,10 +479,7 @@ A comment about the addition of line 15
     (should-error (magit-gh-submit-review) :type 'user-error)))
 
 (ert-deftest magit-gh--test-submission-rejected-if-review-not-started ()
-  (magit-gh--discard-review-draft magit-gh--test-pr)
-  (with-mocks ((magit-gh--request-sync-internal #'mock-github-api)
-               (magit-gh--get-current-pr (lambda () magit-gh--test-pr)))
-    (should-error (magit-gh-submit-review) :type 'user-error)))
+  (should-error (magit-gh-submit-review) :type 'user-error))
 
 (ert-deftest magit-gh--test-submission-review-body-only ()
   (magit-gh--discard-review-draft magit-gh--test-pr)

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -478,6 +478,12 @@ A comment about the addition of line 15
     (magit-gh-start-review)
     (should-error (magit-gh-submit-review) :type 'user-error)))
 
+(ert-deftest magit-gh--test-submission-rejected-if-review-not-started ()
+  (magit-gh--discard-review-draft magit-gh--test-pr)
+  (with-mocks ((magit-gh--request-sync-internal #'mock-github-api)
+               (magit-gh--get-current-pr (lambda () magit-gh--test-pr)))
+    (should-error (magit-gh-submit-review) :type 'user-error)))
+
 (ert-deftest magit-gh--test-submission-review-body-only ()
   (magit-gh--discard-review-draft magit-gh--test-pr)
   (let (mock-calls)


### PR DESCRIPTION
User must call `start-review` before `submit-review`. Error if they
don't.