### PR TITLE
Allow force-refreshing PR from Github

### DIFF
--- a/magit-gh-comments-core.el
+++ b/magit-gh-comments-core.el
@@ -73,7 +73,7 @@
 ;;;###autoload
 (setq magit-pull-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]      'magit-gh-show-reviews)
+    (define-key map [remap magit-visit-thing]      'magit-gh-show-pr)
     map))
 
 (defun magit-pull-request--buffer-name (mode lock-value)
@@ -89,7 +89,7 @@
             number)))
 
 ;;;###autoload
-(defun magit-gh-show-reviews (&optional pr)
+(defun magit-gh-show-pr (&optional pr)
   (interactive)
   (let ((pr (or pr (magit-gh--capture-current-pull-request)))
         (magit-generate-buffer-name-function #'magit-pull-request--buffer-name))

--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -268,6 +268,7 @@ to colon-prefixed keywords. L can be an alist or a list of alists."
 
 (defun magit-gh--list-reviews (pr)
   "Return a list of reviews on the given PR."
+  (setq magit-gh--request-cache nil)
   (let* ((reviews (magit-gh--request-sync
                    (magit-gh--url-for-pr-reviews pr)
                    :headers `(("Authorization" . ,(format "token %s" (magit-gh--get-oauth-token))))
@@ -286,7 +287,8 @@ to colon-prefixed keywords. L can be an alist or a list of alists."
                     :headers `(("Authorization" . ,(format "token %s" (magit-gh--get-oauth-token))))
                     :parser #'magit-gh--parse-json-array))
          (comments (mapcar (lambda (comment)
-                             (make-magit-gh-comment :review-id (alist-get :pull_request_review_id comment)
+                             (make-magit-gh-comment :id (alist-get :id comment)
+                                                    :review-id (alist-get :pull_request_review_id comment)
                                                     :file (alist-get :path comment)
                                                     :commit-sha (alist-get :original_commit_id comment)
                                                     :gh-pos (alist-get :position comment)

--- a/magit-pull-request.el
+++ b/magit-pull-request.el
@@ -35,6 +35,11 @@ See also `magit-buffer-lock-functions'."
 (push (cons 'magit-pull-request-mode #'magit-gh-pull-request--lock-value)
       magit-buffer-lock-functions)
 
+(defun magit-pull-request-reload-from-github ()
+  (interactive)
+  (let ((magit-gh--should-skip-cache t))
+    (magit-refresh-buffer)))
+
 (defun magit-pull-request-refresh-buffer (pr &rest _refresh-args)
   ;; We'll need a reference to the PR in our magit-diff refresh hook
   (setq-local magit-gh--current-pr (magit-gh--hydrate-pr-from-github pr))

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -104,6 +104,12 @@ def foo():
          (position . nil)
          (original_position . 10)
          (original_commit_id . "abcdef")
+         (user (login . "spiderman")))
+        ((id . 4)
+         (pull_request_review_id . 43)
+         (body . "A response to a comment about the removal of line 2")
+         (in_reply_to . 1)
+         (original_commit_id . "abcdef")
          (user (login . "spiderman")))))
 
 (setq
@@ -348,6 +354,10 @@ A comment about the removal of line 2
                                                       :offset 2))))
         (should (equal (caar magit-diff-calls)
                        (magit-gh-pr-diff-range magit-gh--test-pr))))
+      (magit-gh--section-search-forward
+       (magit-gh--section-type-matcher 'comment))
+      (should (magit-gh--looking-at-p "A response to a comment about the removal of line 2
+- spiderman"))
       (magit-gh--section-search-forward
        (magit-gh--section-type-matcher 'review))
       (should (magit-gh--looking-at-p "Review by spiderman"))

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -298,7 +298,7 @@ index 9fda99d..f88549a 100644
                                                    (cons args visit-diff-pos-calls)))))
       (when-let ((buf (get-buffer expected-buf-name)))
         (kill-buffer buf))
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       (should (string= expected-buf-name (buffer-name)))
       (goto-char (point-min))
       ;; PR Title and description
@@ -384,8 +384,7 @@ A comment about the addition of line 15
                   (lambda (url &rest request-args)
                     (ht-set! call-counts url (1+ (ht-get call-counts url 0)))
                     (apply #'mock-github-api url request-args))))
-      ;; TODO: Rename this to show PR?
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       ;; once to hydrate the PR, once to fetch diff
       (should (= 2 (ht-get call-counts (magit-gh--url-for-pr magit-gh--test-pr) 0)))
       (should (= 1 (ht-get call-counts (magit-gh--url-for-pr-reviews magit-gh--test-pr) 0)))
@@ -484,10 +483,10 @@ A comment about the addition of line 15
 (ert-deftest magit-gh--test-review-buffer-persistence ()
   (with-mocks ((magit-gh--request-sync-internal #'mock-github-api)
                (magit-gh--get-current-pr (lambda () magit-gh--test-pr)))
-    (magit-gh-show-reviews magit-gh--test-pr)
+    (magit-gh-show-pr magit-gh--test-pr)
     (let ((review-buf (current-buffer)))
       (should (string= (buffer-name review-buf) "PR: magit-gh-comments (#0)"))
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       (should (equal review-buf (current-buffer))))))
 
 (ert-deftest magit-gh--test-submission-rejected-if-empty ()

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -139,4 +139,9 @@ buzz"
   (should (equalp "foo" (s-dedent "  foo")))
   (should (equalp "foo" (s-dedent "foo"))))
 
+(defun magit-gh--simulate-command (key &rest args)
+  "Simulate the interactive command bound to KEY and supply ARGS"
+  (let ((response-fn (key-binding key t)))
+    (apply response-fn args)))
+
 ;;; test-helper.el ends here


### PR DESCRIPTION
**Allow force-refreshing PR from Github**
Add a new command, `magit-pull-request-reload-from-github`, which
ignores any cached responses and forces a refresh by calling the
Github API.

**Rename magit-gh-show-{reviews,pr}**
This name was misleading now that we have separate major modes for PRs
and Reviews. This function actually populates the PR, not a review.

**Add ability to reply-to comments**
I don't have WiFi in Cuba, so this hasn't been tested beyond
the (offline) unit tests. I've chosen to save each comment in a review
draft rather than immediately post it to Github, which I'm fairly sure
is what the Github web UI does. I may revisit this later.

**Implement reply-to comments**