### PR TITLE
Allow force-refreshing PR from Github

### DIFF
--- a/magit-gh-comments-core.el
+++ b/magit-gh-comments-core.el
@@ -73,7 +73,7 @@
 ;;;###autoload
 (setq magit-pull-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]      'magit-gh-show-reviews)
+    (define-key map [remap magit-visit-thing]      'magit-gh-show-pr)
     map))
 
 (defun magit-pull-request--buffer-name (mode lock-value)
@@ -89,7 +89,7 @@
             number)))
 
 ;;;###autoload
-(defun magit-gh-show-reviews (&optional pr)
+(defun magit-gh-show-pr (&optional pr)
   (interactive)
   (let ((pr (or pr (magit-gh--capture-current-pull-request)))
         (magit-generate-buffer-name-function #'magit-pull-request--buffer-name))

--- a/magit-pull-request.el
+++ b/magit-pull-request.el
@@ -35,6 +35,11 @@ See also `magit-buffer-lock-functions'."
 (push (cons 'magit-pull-request-mode #'magit-gh-pull-request--lock-value)
       magit-buffer-lock-functions)
 
+(defun magit-pull-request-reload-from-github ()
+  (interactive)
+  (let ((magit-gh--should-skip-cache t))
+    (magit-refresh-buffer)))
+
 (defun magit-pull-request-refresh-buffer (pr &rest _refresh-args)
   ;; We'll need a reference to the PR in our magit-diff refresh hook
   (setq-local magit-gh--current-pr (magit-gh--hydrate-pr-from-github pr))

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -298,7 +298,7 @@ index 9fda99d..f88549a 100644
                                                    (cons args visit-diff-pos-calls)))))
       (when-let ((buf (get-buffer expected-buf-name)))
         (kill-buffer buf))
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       (should (string= expected-buf-name (buffer-name)))
       (goto-char (point-min))
       ;; PR Title and description
@@ -384,8 +384,7 @@ A comment about the addition of line 15
                   (lambda (url &rest request-args)
                     (ht-set! call-counts url (1+ (ht-get call-counts url 0)))
                     (apply #'mock-github-api url request-args))))
-      ;; TODO: Rename this to show PR?
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       ;; once to hydrate the PR, once to fetch diff
       (should (= 2 (ht-get call-counts (magit-gh--url-for-pr magit-gh--test-pr) 0)))
       (should (= 1 (ht-get call-counts (magit-gh--url-for-pr-reviews magit-gh--test-pr) 0)))
@@ -484,10 +483,10 @@ A comment about the addition of line 15
 (ert-deftest magit-gh--test-review-buffer-persistence ()
   (with-mocks ((magit-gh--request-sync-internal #'mock-github-api)
                (magit-gh--get-current-pr (lambda () magit-gh--test-pr)))
-    (magit-gh-show-reviews magit-gh--test-pr)
+    (magit-gh-show-pr magit-gh--test-pr)
     (let ((review-buf (current-buffer)))
       (should (string= (buffer-name review-buf) "PR: magit-gh-comments (#0)"))
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       (should (equal review-buf (current-buffer))))))
 
 (ert-deftest magit-gh--test-submission-rejected-if-empty ()


### PR DESCRIPTION
**Allow force-refreshing PR from Github**
Add a new command, `magit-pull-request-reload-from-github`, which
ignores any cached responses and forces a refresh by calling the
Github API.

**Rename magit-gh-show-{reviews,pr}**
This name was misleading now that we have separate major modes for PRs
and Reviews. This function actually populates the PR, not a review.