### PR TITLE
Allow replies to comments. Display comment threads 

### DIFF
--- a/magit-gh-comments-core.el
+++ b/magit-gh-comments-core.el
@@ -745,35 +745,37 @@ and value."
   (let ((review->comment-threads (magit-gh--group-comments-by-thread reviews)))
     (magit-gh--sorted-ht-each
      (lambda (review comment-threads)
-       (magit-insert-section (review review)
-         (magit-insert-heading (format "Review by %s"
-                                       (magit-gh-review-author review)))
-         (if-let ((body (or (if (string-empty-p (magit-gh-review-body review))
-                                nil
-                              (magit-gh-review-body review))
-                            (and (equal (magit-gh-review-state review) 'pending)
-                                 magit-gh--review-body-placeholder-text))))
-             (magit-insert-section (review-body)
-               (insert (magit-gh--text-with-keymap body
-                                                   `(,(kbd "C-c '") . ,'magit-gh--edit-prose)))
-               (insert "\n")))
-         (dolist (thread comment-threads)
-           (letfn ((make-heading (lambda (comment)
-                                   (format "%sComment at %s"
-                                           (if (magit-gh-comment-is-outdated comment)
-                                               "[Outdated] "
-                                             "")
-                                           "<timestamp>"))))
-             (if (> (length thread) 1)
-                 (magit-insert-section (thread thread)
-                   (magit-insert-heading (make-heading (car thread)))
-                   (dolist (comment thread)
-                     (magit-gh--insert-comment comment pr diff-body)))
-               (dolist (comment thread)
-                 (magit-gh--insert-comment comment
-                                           pr
-                                           diff-body
-                                           (make-heading comment))))))))
+       (unless (and (string-empty-p (magit-gh-review-body review))
+                    (not comment-threads))
+         (magit-insert-section (review review)
+           (magit-insert-heading (format "Review by %s"
+                                         (magit-gh-review-author review)))
+           (if-let ((body (or (if (string-empty-p (magit-gh-review-body review))
+                                  nil
+                                (magit-gh-review-body review))
+                              (and (equal (magit-gh-review-state review) 'pending)
+                                   magit-gh--review-body-placeholder-text))))
+               (magit-insert-section (review-body)
+                 (insert (magit-gh--text-with-keymap body
+                                                     `(,(kbd "C-c '") . ,'magit-gh--edit-prose)))
+                 (insert "\n")))
+           (dolist (thread comment-threads)
+             (letfn ((make-heading (lambda (comment)
+                                     (format "%sComment at %s"
+                                             (if (magit-gh-comment-is-outdated comment)
+                                                 "[Outdated] "
+                                               "")
+                                             "<timestamp>"))))
+               (if (> (length thread) 1)
+                   (magit-insert-section (thread thread)
+                     (magit-insert-heading (make-heading (car thread)))
+                     (dolist (comment thread)
+                       (magit-gh--insert-comment comment pr diff-body)))
+                 (dolist (comment thread)
+                   (magit-gh--insert-comment comment
+                                             pr
+                                             diff-body
+                                             (make-heading comment)))))))))
      #'magit-gh-review-id ;; TODO: should this be created-at instead?
      review->comment-threads)))
 

--- a/magit-gh-comments-core.el
+++ b/magit-gh-comments-core.el
@@ -73,7 +73,7 @@
 ;;;###autoload
 (setq magit-pull-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]      'magit-gh-show-reviews)
+    (define-key map [remap magit-visit-thing]      'magit-gh-show-pr)
     map))
 
 (defun magit-pull-request--buffer-name (mode lock-value)
@@ -89,7 +89,7 @@
             number)))
 
 ;;;###autoload
-(defun magit-gh-show-reviews (&optional pr)
+(defun magit-gh-show-pr (&optional pr)
   (interactive)
   (let ((pr (or pr (magit-gh--capture-current-pull-request)))
         (magit-generate-buffer-name-function #'magit-pull-request--buffer-name))

--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -268,6 +268,7 @@ to colon-prefixed keywords. L can be an alist or a list of alists."
 
 (defun magit-gh--list-reviews (pr)
   "Return a list of reviews on the given PR."
+  (setq magit-gh--request-cache nil)
   (let* ((reviews (magit-gh--request-sync
                    (magit-gh--url-for-pr-reviews pr)
                    :headers `(("Authorization" . ,(format "token %s" (magit-gh--get-oauth-token))))
@@ -286,7 +287,8 @@ to colon-prefixed keywords. L can be an alist or a list of alists."
                     :headers `(("Authorization" . ,(format "token %s" (magit-gh--get-oauth-token))))
                     :parser #'magit-gh--parse-json-array))
          (comments (mapcar (lambda (comment)
-                             (make-magit-gh-comment :review-id (alist-get :pull_request_review_id comment)
+                             (make-magit-gh-comment :id (alist-get :id comment)
+                                                    :review-id (alist-get :pull_request_review_id comment)
                                                     :file (alist-get :path comment)
                                                     :commit-sha (alist-get :original_commit_id comment)
                                                     :gh-pos (alist-get :position comment)

--- a/magit-pull-request.el
+++ b/magit-pull-request.el
@@ -35,6 +35,11 @@ See also `magit-buffer-lock-functions'."
 (push (cons 'magit-pull-request-mode #'magit-gh-pull-request--lock-value)
       magit-buffer-lock-functions)
 
+(defun magit-pull-request-reload-from-github ()
+  (interactive)
+  (let ((magit-gh--should-skip-cache t))
+    (magit-refresh-buffer)))
+
 (defun magit-pull-request-refresh-buffer (pr &rest _refresh-args)
   ;; We'll need a reference to the PR in our magit-diff refresh hook
   (setq-local magit-gh--current-pr (magit-gh--hydrate-pr-from-github pr))

--- a/magit-review.el
+++ b/magit-review.el
@@ -73,7 +73,8 @@ See also `magit-buffer-lock-functions'."
                                    (magit-gh-comment-file comment)
                                    (magit-gh-comment-commit-sha comment)
                                    (magit-gh-comment-gh-pos comment)
-                                   (magit-gh-comment-text comment))))
+                                   (magit-gh-comment-text comment)
+                                   (magit-gh-comment-in-reply-to comment))))
     (magit-gh--discard-review-draft pr)
     (magit-kill-this-buffer)))
 

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -104,6 +104,12 @@ def foo():
          (position . nil)
          (original_position . 10)
          (original_commit_id . "abcdef")
+         (user (login . "spiderman")))
+        ((id . 4)
+         (pull_request_review_id . 43)
+         (body . "A response to a comment about the removal of line 2")
+         (in_reply_to . 1)
+         (original_commit_id . "abcdef")
          (user (login . "spiderman")))))
 
 (setq
@@ -348,6 +354,10 @@ A comment about the removal of line 2
                                                       :offset 2))))
         (should (equal (caar magit-diff-calls)
                        (magit-gh-pr-diff-range magit-gh--test-pr))))
+      (magit-gh--section-search-forward
+       (magit-gh--section-type-matcher 'comment))
+      (should (magit-gh--looking-at-p "A response to a comment about the removal of line 2
+- spiderman"))
       (magit-gh--section-search-forward
        (magit-gh--section-type-matcher 'review))
       (should (magit-gh--looking-at-p "Review by spiderman"))

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -90,13 +90,15 @@ def foo():
          (body . "A comment about the removal of line 2")
          (path . "f")
          (position . 2)
-         (user (login . "astahlman")))
+         (user (login . "astahlman"))
+         (created_at . "2019-01-01T00:00:00Z"))
         ((id . 2)
          (pull_request_review_id . 43)
          (body . "A comment about the addition of line 15")
          (path . "f")
          (position . 9)
-         (user (login . "spiderman")))
+         (user (login . "spiderman"))
+         (created_at . "2019-01-01T00:00:00Z"))
         ((id . 3)
          (pull_request_review_id . 43)
          (body . "Some other comment that's been resolved")
@@ -104,13 +106,14 @@ def foo():
          (position . nil)
          (original_position . 10)
          (original_commit_id . "abcdef")
-         (user (login . "spiderman")))
+         (user (login . "spiderman"))
+         (created_at . "2019-01-01T00:00:00Z"))
         ((id . 4)
          (pull_request_review_id . 43)
          (body . "A response to a comment about the removal of line 2")
-         (in_reply_to . 1)
-         (original_commit_id . "abcdef")
-         (user (login . "spiderman")))))
+         (in_reply_to_id . 1)
+         (user (login . "spiderman"))
+         (created_at . "2019-01-01T00:00:00Z"))))
 
 (setq
 
@@ -190,38 +193,39 @@ With a carriage-return + line-feed.")
 
 (ert-deftest test-magit-gh--github-fetch-comments ()
   ;; TODO: Test against the comment context given this diff body
-  (let* ((diff-body magit-gh--test-diff-body)
-         (sort-pred (lambda (x y)
-                      (if (equal (magit-gh-comment-review-id x)
-                                 (magit-gh-comment-review-id y))
-                          (string< (magit-gh-comment-text x)
-                                   (magit-gh-comment-text y))
-                        (< (magit-gh-comment-review-id x)
-                           (magit-gh-comment-review-id y)))))
-         (retrieved-comments (with-mocks ((magit-gh--request-sync-internal #'mock-github-api))
-                               (magit-gh--list-comments magit-gh--test-pr)))
-         (retrieved-comments (sort retrieved-comments sort-pred))
-         (expected-comments (list (make-magit-gh-comment :id 1
-                                                         :review-id 42
-                                                         :author "astahlman"
-                                                         :text "A comment about the removal of line 2"
-                                                         :file "f"
-                                                         :gh-pos 2)
-                                  (make-magit-gh-comment :id 2
-                                                         :review-id 43
-                                                         :author "spiderman"
-                                                         :text "A comment about the addition of line 15"
-                                                         :file "f"
-                                                         :gh-pos 9)
-                                  (make-magit-gh-comment :id 3
-                                                         :review-id 43
-                                                         :author "spiderman"
-                                                         :text "Some other comment that's been resolved"
-                                                         :file "f"
-                                                         :is-outdated t
-                                                         :original-gh-pos 10
-                                                         :commit-sha "abcdef"))))
-    (should (equal expected-comments retrieved-comments))))
+  (let ((retrieved-comments (with-mocks ((magit-gh--request-sync-internal #'mock-github-api))
+                              (magit-gh--list-comments magit-gh--test-pr)))
+        (expected-comments (list (make-magit-gh-comment :id 1
+                                                        :review-id 42
+                                                        :author "astahlman"
+                                                        :text "A comment about the removal of line 2"
+                                                        :file "f"
+                                                        :gh-pos 2
+                                                        :created-at "2019-01-01T00:00:00Z")
+                                 (make-magit-gh-comment :id 2
+                                                        :review-id 43
+                                                        :author "spiderman"
+                                                        :text "A comment about the addition of line 15"
+                                                        :file "f"
+                                                        :gh-pos 9
+                                                        :created-at "2019-01-01T00:00:00Z")
+                                 (make-magit-gh-comment :id 3
+                                                        :review-id 43
+                                                        :author "spiderman"
+                                                        :text "Some other comment that's been resolved"
+                                                        :file "f"
+                                                        :is-outdated t
+                                                        :original-gh-pos 10
+                                                        :commit-sha "abcdef"
+                                                        :created-at "2019-01-01T00:00:00Z")
+                                 (make-magit-gh-comment :id 4
+                                                        :review-id 43
+                                                        :author "spiderman"
+                                                        :text "A response to a comment about the removal of line 2"
+                                                        :in-reply-to 1
+                                                        :created-at "2019-01-01T00:00:00Z"))))
+    (should (equal expected-comments
+                   (magit-gh--sort retrieved-comments #'magit-gh-comment-id)))))
 
 (ert-deftest magit-gh--test-comment-ctx ()
   (let ((diff-body "diff --git a/f b/f

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -298,7 +298,7 @@ index 9fda99d..f88549a 100644
                                                    (cons args visit-diff-pos-calls)))))
       (when-let ((buf (get-buffer expected-buf-name)))
         (kill-buffer buf))
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       (should (string= expected-buf-name (buffer-name)))
       (goto-char (point-min))
       ;; PR Title and description
@@ -384,8 +384,7 @@ A comment about the addition of line 15
                   (lambda (url &rest request-args)
                     (ht-set! call-counts url (1+ (ht-get call-counts url 0)))
                     (apply #'mock-github-api url request-args))))
-      ;; TODO: Rename this to show PR?
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       ;; once to hydrate the PR, once to fetch diff
       (should (= 2 (ht-get call-counts (magit-gh--url-for-pr magit-gh--test-pr) 0)))
       (should (= 1 (ht-get call-counts (magit-gh--url-for-pr-reviews magit-gh--test-pr) 0)))
@@ -484,10 +483,10 @@ A comment about the addition of line 15
 (ert-deftest magit-gh--test-review-buffer-persistence ()
   (with-mocks ((magit-gh--request-sync-internal #'mock-github-api)
                (magit-gh--get-current-pr (lambda () magit-gh--test-pr)))
-    (magit-gh-show-reviews magit-gh--test-pr)
+    (magit-gh-show-pr magit-gh--test-pr)
     (let ((review-buf (current-buffer)))
       (should (string= (buffer-name review-buf) "PR: magit-gh-comments (#0)"))
-      (magit-gh-show-reviews magit-gh--test-pr)
+      (magit-gh-show-pr magit-gh--test-pr)
       (should (equal review-buf (current-buffer))))))
 
 (ert-deftest magit-gh--test-submission-rejected-if-empty ()

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -139,4 +139,9 @@ buzz"
   (should (equalp "foo" (s-dedent "  foo")))
   (should (equalp "foo" (s-dedent "foo"))))
 
+(defun magit-gh--simulate-command (key &rest args)
+  "Simulate the interactive command bound to KEY and supply ARGS"
+  (let ((response-fn (key-binding key t)))
+    (apply response-fn args)))
+
 ;;; test-helper.el ends here


### PR DESCRIPTION
Tests are failing - I'm going to follow up with a commit to fix
them (I refactored the test infrastructure for making assertions about
the magit-section tree, but don't want to make this commit too big).

Note that there is one known bug in which pending comments aren't
displayed when submitting a review. I'll follow up with a unit test to
expose the bug and a fix in a subsequent commit.