### PR TITLE
Re-introduce magit-gh-comments

### DIFF
--- a/magit-gh-comments-github.el
+++ b/magit-gh-comments-github.el
@@ -4,6 +4,7 @@
 (require 'json)
 (require 'request)
 (require 'magit-git)
+(require 'dash)
 
 ;; https://developer.github.com/v3/pulls/#list-pull-requests
 ;; TODO: Add title, body, and state (at a minimum)
@@ -29,6 +30,9 @@
   threads
   commit-sha
   state)
+
+(defun magit-gh-review-comments (review)
+  (-flatten (magit-gh-review-threads review)))
 
 (defun magit-gh-pr-to-string (pr)
   (format "%s#%s"
@@ -420,7 +424,7 @@ API reference: https://developer.github.com/v3/pulls/reviews/#example"
         (payload `((:commit_id . ,(magit-gh-review-commit-sha review))
                    (:body . ,(magit-gh-review-body review)))))
     (when-let ((comments (mapcar #'magit-gh-comment--to-github-format
-                                 (mapcar #'car (magit-gh-review-threads review)))))
+                                 (magit-gh-review-comments review))))
       (push `(:comments . ,comments) payload))
     (when-let ((event (and (not (equal 'pending (magit-gh-review-state review)))
                            (magit-gh-review-state review))))

--- a/magit-review.el
+++ b/magit-review.el
@@ -53,7 +53,7 @@ See also `magit-buffer-lock-functions'."
                      (make-magit-gh-review :state state
                                            :commit-sha (cdr (magit-split-range
                                                              (magit-gh-pr-diff-range pr))))))
-         (comments (and review (mapcar #'car (magit-gh-review-threads review))))
+         (comments (and review (magit-gh-review-comments review)))
          (review-body-section (car (magit-gh--filter-sections
                                     (lambda (section)
                                       (equal (oref section type)

--- a/test/magit-gh-comments-test.el
+++ b/test/magit-gh-comments-test.el
@@ -425,8 +425,8 @@ With a carriage-return \\+ line-feed.\n+"))
 (ert-deftest magit-gh--test-add-pending-comments ()
   (magit-gh--discard-review-draft magit-gh--test-pr)
   (magit-gh--simulate-adding-comments magit-gh--test-comments)
-  (should (equal (mapcar #'car (magit-gh-review-threads
-                                (magit-gh--get-review-draft magit-gh--test-pr)))
+  (should (equal (magit-gh-review-comments
+                  (magit-gh--get-review-draft magit-gh--test-pr))
                  (reverse magit-gh--test-comments))))
 
 


### PR DESCRIPTION
The new and improved version just flattens the value of the `threads`
field.