### PR TITLE
Fix a couple of bugs in utility functions

### DIFF
--- a/magit-gh-comments-utils.el
+++ b/magit-gh-comments-utils.el
@@ -26,7 +26,7 @@ The start and end of the overlays are inclusive."
 
 (defun magit-gh--delete-overlays-at-point ()
   (interactive)
-  (dolist (ov (overlays-at-point))
+  (dolist (ov (magit-gh--overlays-at-point))
     (delete-overlay ov)))
 
 ;; TODO: This probably doesn't belong here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -115,19 +115,23 @@ failures.
 Inspired by textwrap.dedent, in Python."
   (let ((margin (apply #'min
                        (mapcar (lambda (l)
-                                 (or (string-match "[^ ]+" l) 0))
+                                 (or (string-match "[^ ]+" l) 10000000))
                                (s-lines s)))))
     (s-join "\n"
-            (mapcar (lambda (l) (substring l margin))
+            (mapcar (lambda (l) (if (< margin (length l))
+                                    (substring l margin)
+                                  l))
                     (s-lines s)))))
 
 (ert-deftest magit-gh--test-s-dedent ()
   (should (equalp
 "foo
-bar"
+bar
+"
            (s-dedent "\
                      foo
-                     bar")))
+                     bar
+")))
   (should (equalp "\
  foo
   bar


### PR DESCRIPTION
1. Reference the correct function name in the delete overlays function
2. Make `s-dedent` ignore blank lines